### PR TITLE
review

### DIFF
--- a/Dashboard/battery_web_dashboard.py
+++ b/Dashboard/battery_web_dashboard.py
@@ -34,6 +34,7 @@ def parse_frame(data):
         time_per_cycle = data[28] + data[29]*256
         adbms_temp = (data[30] + data[31]*256) * 0.01
 
+        # Python has multi-line strings ;)
         html = f"Total Voltage: {totalVoltage:.2f} V<br>"
         html += f"Highest Cell Voltage: {highestCellVoltage:.2f} V<br>"
         html += f"Lowest Cell Voltage: {lowestCellVoltage:.2f} V<br>"

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The used Ubuntu version for this project was **Ubuntu 24.04**
     west flash
     ```
 
-# Class Diagram
-The class diagram shows the different classes used and their depencies to each other. As a first instance only public function are declared to get an overall view of the program.
+# C Module Diagram
+This diagram shows the different C modules and their relationship to each other. Only public function are declared to get an overall view of the program.
 
 ```mermaid
 classDiagram

--- a/boards/nucleo_l432kc.overlay
+++ b/boards/nucleo_l432kc.overlay
@@ -1,6 +1,3 @@
-/{
-};
-
 &can1 {
     status       = "okay";
     bitrate      = <500000>;

--- a/include/Battery.h
+++ b/include/Battery.h
@@ -121,64 +121,64 @@ extern BatterySystemTypeDef battery_values;
  * @brief Initializes GPIOs related to battery feedback and charger sensing.
  * @return 0 on success, negative errno code otherwise.
  */
-extern int battery_init(void);
+int battery_init(void);
 
 /**
  * @brief Retrieves the current status bitfield from the battery system.
  * @return Battery status bitfield (8-bit)
  */
-extern uint8_t battery_get_status_code(void);
+uint8_t battery_get_status_code(void);
 
 /**
  * @brief Retrieves the current error bitfield from the battery system.
  * @return Battery error code (8-bit)
  */
-extern uint8_t battery_get_error_code(void);
+uint8_t battery_get_error_code(void);
 
 /**
  * @brief Converts raw voltage (in 100 µV units) to temperature in °C.
  * @param volt_100uV Voltage in units of 100 µV
  * @return Temperature in degrees Celsius
  */
-extern uint8_t battery_volt2celsius(uint16_t volt_100uV);
+uint8_t battery_volt2celsius(uint16_t volt_100uV);
 
 /**
  * @brief Sets error flags in the battery error field.
  * @param Bitmask (8-bit) representing error flags to set
  */
-extern void battery_set_error_flag(uint8_t mask);
+void battery_set_error_flag(uint8_t mask);
 
 /**
  * @brief Resets all battery error flags to zero.
  */
-extern void battery_reset_error_flag(uint8_t mask);
+void battery_reset_error_flag(uint8_t mask);
 
 /**
  * @brief Checks for system errors and updates the battery error state accordingly.
  * @return 0 if OK, <0 if errors are detected
  */
-extern int battery_check_state(void);
+int battery_check_state(void);
 
 /**
  * @brief Stops all active cell balancing operations.
  */
-extern void battery_stop_balancing(void);
+void battery_stop_balancing(void);
 
 /**
  * @brief Handles the charging logic including balance management.
  */
-extern void battery_charging(void);
+void battery_charging(void);
 
 /**
  * @brief Refreshes the IVT (current sensor) watchdog timer.
  */
-extern void battery_refresh_ivt_timer(void);
+void battery_refresh_ivt_timer(void);
 
 /**
  * @brief Executes precharge logic by managing AIR +/- and precharge relays.
  * @return 0 on successful precharge, <0 if feedback is incorrect
  */
-extern int battery_precharge_logic(void);
+int battery_precharge_logic(void);
 
 
 #endif /* INC_BATTERY_H_ */

--- a/include/CAN_Bus.h
+++ b/include/CAN_Bus.h
@@ -96,47 +96,20 @@ extern struct k_sem test_ack_sem;
  *
  * @return 0 on success, error code otherwise.
  */
-extern int can_init(void);
-
-/**
- * @brief Sends an 8-byte CAN frame to the specified address.
- *
- * @param address Target CAN ID.
- * @param TxBuffer Pointer to 8-byte data buffer.
- * @return 0 on success, error code otherwise.
- */
-int can_send_8bytes(uint32_t address, uint8_t *TxBuffer);
-
-/**
- * @brief Sends a CAN frame with specified byte length.
- *
- * @param address Target CAN ID.
- * @param TxBuffer Pointer to data buffer.
- * @param length Number of bytes to send.
- * @return 0 on success, error code otherwise.
- */
-int can_send_ivt_nbytes(uint32_t address, uint8_t *TxBuffer, uint8_t length);
-
-/**
- * @brief Formats and sends sensor data to the ECU.
- *
- * @param GPIO_Input GPIO input encoding system status.
- * @return 0 on success, error code otherwise.
- */
-int can_send_ecu(void);
+int can_init(void);
 
 /**
  * @brief Checks if the ECU flag is OK or NOK. OK means the accumulator can be connected.
  *
  * @return 1 if ECU is OK, 0 otherwise.
  */
-extern int can_get_ecu_state();
+int can_get_ecu_state();
 
 /**
  * @brief Initializes IVT sensor with measurement configurations.
  *
  * @return 0 on success, error code otherwise.
  */
-extern int can_ivt_init(void);
+int can_ivt_init(void);
 
 #endif

--- a/include/SPI_MB.h
+++ b/include/SPI_MB.h
@@ -121,13 +121,12 @@ static const struct gpio_dt_spec spi_cs_pb1_spec = {
     .dt_flags = DT_GPIO_HOG_FLAGS_BY_IDX(DT_NODELABEL(spi_cs_pb1), 0),
   };
 
-extern uint16_t spi_generate_pec(const uint8_t data[], size_t len);
-extern int spi_read_voltages(uint16_t *data_buffer);
-extern int spi_read_temp(uint16_t *data_buffer);
-extern uint16_t spi_read_adbms_temp();
-extern int spi_set_discharge_cell_x(uint32_t *data_buffer);
-void spi_wake_up();
+uint16_t spi_generate_pec(const uint8_t data[], size_t len);
+int spi_read_voltages(uint16_t *data_buffer);
 int spi_adbms1818_hw_init();
-extern int spi_loopback();
+int spi_read_temp(uint16_t *data_buffer);
+uint16_t spi_read_adbms_temp();
+int spi_set_discharge_cell_x(uint32_t *data_buffer);
+int spi_loopback();
 
 #endif /* INC_SPI_MB_H_ */

--- a/source/main.c
+++ b/source/main.c
@@ -33,7 +33,7 @@ typedef enum
 int main(void)
 {
 	int ret; 
-	bool led_state = true;
+	bool led_state = true; // variable is not used
 
 	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 	if (ret < 0) {
@@ -64,6 +64,7 @@ int main(void)
 	{		
 		ret = gpio_pin_toggle_dt(&led);
 		if (ret < 0) {
+			LOG_ERR("could not toggle led");
 			return 0;
 		}
 		led_state = !led_state;
@@ -96,6 +97,7 @@ int main(void)
 		case STATE_IDLE:
 			LOG_INF("Waiting for ECU OK");
 
+			// can_get_ecu_state() always returns 0?
 			current_ecu_state = can_get_ecu_state();
 
 			if (previous_ecu_state == BATTERY_OFF && current_ecu_state == BATTERY_ON)
@@ -120,6 +122,7 @@ int main(void)
 			battery_charging();
 			LOG_INF("Battery management process running");
 
+			// can_get_ecu_state() always returns 0?
 			current_ecu_state = can_get_ecu_state();
 
 			if (previous_ecu_state == BATTERY_ON && current_ecu_state == BATTERY_OFF)
@@ -143,8 +146,8 @@ int main(void)
 			}
 			break;
 		default:
-			LOG_INF("default case");
-			break;
+			LOG_ERR("invalid state: %d", state);
+			return 0;
 		}
 
 	}

--- a/source/modules/Battery.c
+++ b/source/modules/Battery.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(battery, LOG_LEVEL_INF);
 
 /* Variables */
 static uint64_t ivt_deadline_ms;
+// this is a bad variable name as this could be used elsewhere instead of main
 struct k_event error_to_main;
 K_EVENT_DEFINE(error_to_main);
 BatterySystemTypeDef battery_values;

--- a/source/modules/serial_monitor.c
+++ b/source/modules/serial_monitor.c
@@ -77,6 +77,7 @@
  * @param data Pointer to data payload
  * @param size Length of data payload in bytes
  */
+ // This is a bad function name. Probably better: send_battery_data
  void serial_monitor(const uint8_t *data, uint16_t size)
  {
     static const uint8_t start[] = {0xFF, 0xA3};

--- a/tests/test_CAN_Bus.c
+++ b/tests/test_CAN_Bus.c
@@ -13,6 +13,7 @@ ZTEST(can_bus_tests, test_can_init)
     int ret = can_init();
 
     // 0 for initialization success, -16 for CAN Mode already set
+    // this does not do what you think it does: `0 | -16` evaluates to -16 (| is binary or)
     zassert_equal(ret, 0 | -16, "can_init failed with error code %d", ret);
 }
 


### PR DESCRIPTION
- Fix the kconfig build warnings (`CAN_MAX_FILTER` and `PRINTK` being ignored)
- Format your code with clang-format using zephyr's config (`$ZEPHYR_BASE/.clang-format`)
- Don't unnecessarily use `extern` and remove prototypes of private functions from headers.
  You seem to be misunderstanding how `extern` works, `extern` does not mean public.
  Revise the C module diagram accordingly.
- Sharing resources using `extern` across modules is not good practice (e.g. `error_to_main`).
  It is better to have a function return them (e.g. `int battery_init(struct k_event *error_to_main)`).
- Document how to run the tests. The project does not build with `CONFIG_ZTEST` enabled.

(This PR is not intended to be merged, I am just using the PR infrastructure as a way of providing my review to you.)
